### PR TITLE
 Use realpath(PROGRAM_FILE) when computing path to res/ dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+## Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+
+os:
+  - osx
+  - linux
+
+julia:
+  - 1.0
+  - nightly
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia: nightly
+
+# Because we don't build all branches, manualy add a trigger to always build master.
+branches:
+  only:
+  - master
+
+notifications:
+  email: false
+
+#script: # the default script is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Example"); Pkg.test("Example"; coverage=true)';
+
+after_success:
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+#  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - linux
 
 julia:
-  - 1.0
+  - 1.1
   - nightly
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/Project.toml
+++ b/Project.toml
@@ -5,3 +5,9 @@ version = "0.1.0"
 
 [compat]
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/ApplicationBuilderAppUtils.jl
+++ b/src/ApplicationBuilderAppUtils.jl
@@ -29,7 +29,9 @@ be `/path/to/MyApp/res`.
 """
 function get_bundle_resources_dir()
     # When statically compiled, PROGRAM_FILE is set by ApplicationBuilder/src/program.c
-    full_binary_name = PROGRAM_FILE
+    # Use `realpath()` to follow any potential symlinks so that we end up navigating to the
+    # true bundle resources directory.
+    full_binary_name = realpath(PROGRAM_FILE)
 
     @static if Sys.isapple()
         m = match(r".app/Contents/MacOS/[^/]+$", full_binary_name)

--- a/test/ApplicationBuilderAppUtils.jl
+++ b/test/ApplicationBuilderAppUtils.jl
@@ -1,0 +1,32 @@
+module ApplicationBuilderAppUtilsTest
+
+using ApplicationBuilderAppUtils
+using Test
+
+function with_tmp_PROGRAM_FILE(f::Function, path)
+    tmpdir = mktempdir()
+    program_file = joinpath(tmpdir, path)
+    mkpath(program_file)
+
+    _orig_PROGRAM_FILE = Base.PROGRAM_FILE
+    try
+        @eval Base PROGRAM_FILE = $program_file
+        f(program_file)
+    finally
+        @eval Base PROGRAM_FILE = $_orig_PROGRAM_FILE
+    end
+end
+
+@testset "bundle_resources" begin
+    @static if Sys.isapple()
+        with_tmp_PROGRAM_FILE("MyApp.app/Contents/MacOS/program") do program_file
+            @test splitpath(ApplicationBuilderAppUtils.get_bundle_resources_dir())[end-2:end] == ["MyApp.app", "Contents", "Resources"]
+        end
+    else
+        with_tmp_PROGRAM_FILE("MyApp/bin/program") do program_file
+            @test splitpath(ApplicationBuilderAppUtils.get_bundle_resources_dir())[end-1:end] == ["MyApp", "res"]
+        end
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,5 @@
+using Test
+
+@testset "ApplicationBuilderAppUtils" begin
+    include("ApplicationBuilderAppUtils.jl")
+end


### PR DESCRIPTION
This fixes `get_bundle_resources_dir()` if the binary path (PROGRAM_FILE) contains a symlink.